### PR TITLE
Fix fail on generic object without explicit classname

### DIFF
--- a/Transformer/SymfonyUidTransformerFactory.php
+++ b/Transformer/SymfonyUidTransformerFactory.php
@@ -46,6 +46,10 @@ final class SymfonyUidTransformerFactory extends AbstractUniqueTypeTransformerFa
             return false;
         }
 
+        if (null === $type->getClassName()) {
+            return false;
+        }
+
         if (!\array_key_exists($type->getClassName(), $this->reflectionCache)) {
             $reflClass = new \ReflectionClass($type->getClassName());
             $this->reflectionCache[$type->getClassName()] = [$reflClass->isSubclassOf(AbstractUid::class), $type->getClassName() === Ulid::class];


### PR DESCRIPTION
Class with comments like this below, that may be generated by Jane 
     * @var object|null
are causing errors on this uid transformer.